### PR TITLE
Removed warning for void parameter and checking on

### DIFF
--- a/source/adios2/toolkit/transportman/dataman/DataMan.h
+++ b/source/adios2/toolkit/transportman/dataman/DataMan.h
@@ -44,7 +44,7 @@ public:
      * @param buffer
      * @param size can't use const due to C libraries...
      */
-    void WriteWAN(const char *buffer, size_t size);
+    void WriteWAN(const void *buffer, size_t size);
 
     void ReadWAN(void *buffer, nlohmann::json jmsg);
 


### PR DESCRIPTION
@JasonRuonanWang try this for the void* conflict on Mac....still not working in full, but it would be good to enable a debugger.